### PR TITLE
fix(theme): display ErrorMsg highlight colors

### DIFF
--- a/lua/abyss/theme.lua
+++ b/lua/abyss/theme.lua
@@ -87,7 +87,7 @@ function M.get(user_opts)
 
     VertSplit = { fg = colors.fg, bg = colors.bg },
 
-    highlight = { fg = colors.red },
+    ErrorMsg = { fg = colors.red },
     WarningMsg = { fg = colors.heavyyellow },
 
     Folded = { fg = colors.darkgrey, bg = colors.none, italic = true },


### PR DESCRIPTION
The highlight colors of ErrorMsg was not displayed. Now, that's fixed.
