### PR TITLE
fix(treesitter): builtin type highlighting

### DIFF
--- a/lua/abyss/theme.lua
+++ b/lua/abyss/theme.lua
@@ -372,6 +372,7 @@ function M.get_treesitter()
     ["@constant.macro"] = { link = "Constant" },
     ["@parameter.reference"] = { link = "@lsp.type.parameter" },
     ["@exception"] = { link = "Exception" },
+    ["@type.builtin"] = { link = "@lsp.type.type" },
 
     -- Typescript
     ["@type.qualifier.typescript"] = { link = "Statement" },


### PR DESCRIPTION
In Neovim 0.10, builtin Treesitter Type highlight printed the wrong color. Now it's fixed.
