### PR TITLE
feat: Treesitter captures names of Neovim v0.10

### DIFF
--- a/lua/abyss/theme.lua
+++ b/lua/abyss/theme.lua
@@ -376,8 +376,14 @@ function M.get_treesitter()
     ["@type.builtin"] = { link = "@lsp.type.type" },
 
     -- Typescript
-    ["@type.qualifier.typescript"] = { link = "Statement" },
     ["@constant.builtin.typescript"] = { link = "Boolean" },
+
+    ["@preproc"] = { link = "PreProc" },
+    ["@include"] = { link = "PreProc" },
+
+    ["@repeat"] = { link = "Statement" },
+    ["@conditional"] = { link = "Statement" },
+    ["@type.qualifier"] = { link = "Statement" }
   }
 end
 


### PR DESCRIPTION
- Delete repeated variable color in Airline theme
- feat(vim-lightline): add abyss theme for vim-lightline
- ci: changes on workflows
- feat: add some new treesitter capture names for v0.10
