### PR TITLE
fix(theme): inlay hints not working correctly

### DIFF
--- a/lua/abyss/theme.lua
+++ b/lua/abyss/theme.lua
@@ -384,7 +384,7 @@ function M.get_treesitter()
 
     ["@repeat"] = { link = "Statement" },
     ["@conditional"] = { link = "Statement" },
-    ["@type.qualifier"] = { link = "Statement" }
+    ["@type.qualifier"] = { link = "Statement" },
   }
 end
 

--- a/lua/abyss/theme.lua
+++ b/lua/abyss/theme.lua
@@ -87,6 +87,7 @@ function M.get(user_opts)
     EndOfBuffer = { link = "NonText" },
 
     VertSplit = { fg = colors.fg, bg = colors.bg },
+    WinSeparator = { link = "VertSplit" },
 
     ErrorMsg = { fg = colors.red },
     WarningMsg = { fg = colors.heavyyellow },

--- a/lua/abyss/theme.lua
+++ b/lua/abyss/theme.lua
@@ -176,6 +176,7 @@ function M.get(user_opts)
       italic = user_opts.italic,
       bold = user_opts.bold,
     },
+    LspInlayHint = { link = "Comment" },
 
     -- Plugins --
     -- Telescope

--- a/lua/abyss/theme.lua
+++ b/lua/abyss/theme.lua
@@ -130,7 +130,7 @@ function M.get(user_opts)
     SpellCap = { fg = colors.yellow, underline = true },
     SpellLocal = { fg = colors.orange, underline = true },
 
-    StatusLine = { fg = colors.none, bg = colors.bg },
+    StatusLine = { fg = colors.none, bg = colors.bg_alt },
     StatusLineNC = { fg = colors.none, bg = colors.black },
 
     TabLine = { fg = colors.lightgrey, bg = colors.bg },

--- a/test/abyss/theme_spec.lua
+++ b/test/abyss/theme_spec.lua
@@ -1,21 +1,17 @@
 local abyss = require("abyss")
 local config = require("abyss.config")
 
-describe("Abyss.nvim", function ()
-  before_each(function ()
-    vim.cmd.colorscheme "abyss"
-  end)
+describe("Abyss.nvim", function()
+  before_each(function() vim.cmd.colorscheme("abyss") end)
 
-  it("works with default setup", function ()
+  it("works with default setup", function()
     abyss.setup()
     assert.are.same(config.default_options, config.options)
   end)
 
-  it("has correct colors_name", function ()
-    assert.are.same("abyss", vim.g.colors_name)
-  end)
+  it("has correct colors_name", function() assert.are.same("abyss", vim.g.colors_name) end)
 
-  it("should change the config", function ()
+  it("should change the config", function()
     local expected = {
       italic_comments = false,
       italic = false,
@@ -29,23 +25,23 @@ describe("Abyss.nvim", function ()
     assert.are.same(expected, config.options)
   end)
 
-  it("has nil overrides", function ()
+  it("has nil overrides", function()
     abyss.setup()
     assert.are.are_nil(config.options.overrides, "Overrides property should be a nil value.")
   end)
 
-  it("has overrides", function ()
+  it("has overrides", function()
     abyss.setup({
       overrides = {
-        String = { fg = "#fffa0c" }
-      }
+        String = { fg = "#fffa0c" },
+      },
     })
 
     assert.are.not_nil(config.options.overrides, "Overrides property must not be a nil value.")
   end)
 
-  describe("Treesitter option", function ()
-    it("should check if vim or neovim is running", function ()
+  describe("Treesitter option", function()
+    it("should check if vim or neovim is running", function()
       abyss.setup()
       local is_vim = vim.fn.has("nvim") ~= 1
       if is_vim then

--- a/test/init.lua
+++ b/test/init.lua
@@ -1,6 +1,6 @@
 local status, error = pcall(function()
   local root = vim.fn.fnamemodify("", ":p:h")
-  for _, name in ipairs { "config", "data", "state", "cache" } do
+  for _, name in ipairs({ "config", "data", "state", "cache" }) do
     vim.env[("XDG_%s_HOME"):format(name:upper())] = root .. "/" .. name
   end
 
@@ -9,17 +9,17 @@ local status, error = pcall(function()
 
   local lazypath = root .. "/plugins/lazy.nvim"
   if not vim.loop.fs_stat(lazypath) then
-    vim.fn.system { "git", "clone", "--filter=blob:none", "https://github.com/folke/lazy.nvim.git", lazypath }
+    vim.fn.system({ "git", "clone", "--filter=blob:none", "https://github.com/folke/lazy.nvim.git", lazypath })
   end
   vim.opt.runtimepath:prepend(lazypath)
 
   require("lazy").setup({
     { "barrientosvctor/abyss.nvim", dev = true },
-    }, {
-      root = lazy_root,
-      dev = {
-        path = lazy_dev_path,
-      },
+  }, {
+    root = lazy_root,
+    dev = {
+      path = lazy_dev_path,
+    },
   })
 
   require("abyss").setup({})


### PR DESCRIPTION
The highlight group for inlay hints (released in NVIM v0.10) was missing, now it's fixed.

## Before

![inlay hints before](https://i.imgur.com/191Fhgp.png)

## After

![inlay hints after](https://i.imgur.com/cDqdp8n.png)

Resolves #35 