### PR TITLE
fix: highlight colors of Whitespace

### DIFF
--- a/lua/abyss/theme.lua
+++ b/lua/abyss/theme.lua
@@ -145,7 +145,7 @@ function M.get(user_opts)
     Visual = { fg = colors.none, bg = colors.darkred },
     VisualNOS = { link = "Visual" },
 
-    Whitespace = { fg = colors.bg, bg = colors.none },
+    Whitespace = { fg = colors.midblue },
 
     WildMenu = { link = "PmenuSel" },
 


### PR DESCRIPTION
- Delete repeated variable color in Airline theme
- feat(vim-lightline): add abyss theme for vim-lightline
- ci: changes on workflows
- feat: add some new treesitter capture names for v0.10
- fix: StatusLine according to new style
- feat(highlights): add WinSeparator
- style: stylua formatting
- fix(theme): inlay hints not working (#35)
- fix(highlight): wrong colors of WildMenu
- feat(highlight): add terminal StatusLine
- fix(highlight): Whitespace color
